### PR TITLE
fix - login에서 axios 사용시 XmlHttpRequest 임시 해결

### DIFF
--- a/src/main/java/com/example/demo/entity/users/user/User.java
+++ b/src/main/java/com/example/demo/entity/users/user/User.java
@@ -1,6 +1,5 @@
 package com.example.demo.entity.users.user;
 
-import com.example.demo.entity.Alarm.AlarmSettings;
 import com.example.demo.entity.community.block.Block;
 import com.example.demo.entity.community.follow.Follow;
 import com.example.demo.entity.community.post.Post;

--- a/src/main/java/com/example/demo/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/demo/handler/OAuth2SuccessHandler.java
@@ -58,9 +58,11 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         redisUtil.setData(accessToken, refreshToken); // 레디스에 리프레시 토큰 저장
 
         response.addHeader("Authorization", "Bearer " + accessToken); // access token은 Authorization 헤더에
+        response.addCookie(createCookie(accessToken)); // accessToken은 쿠키에
         response.addCookie(createCookie(refreshToken)); // refresh token은 쿠키에
         response.setStatus(HttpStatus.OK.value());
-        response.getWriter().write("Social_LOGIN_SUCCESS");
+        response.getWriter().write("SOCIAL_LOGIN_SUCCESS");
+        response.sendRedirect("http://localhost:3000/login/success");
     }
 
     private Cookie createCookie(String value) {


### PR DESCRIPTION
login시 사용자가 axios로 /users/join 요청하면 발생하는 XmlHttpRequest에 대한 임시 해결.

1. 로그인시 axios 로 요청하지 말고 a태그로 요청
2. 로그인 성공시 /login/success로 리디렉션
3. a태그로 로그인하므로 response와 header를 response로 쉽게 받아올 수 가 없어서
4. access token도 cookie로 저장